### PR TITLE
req() an input to prevent crashing when used in a shiny app

### DIFF
--- a/R/fpca-shiny.R
+++ b/R/fpca-shiny.R
@@ -98,7 +98,7 @@ fpcaRun <- function(input, output, session, rfds, ..., debug = FALSE,
   observeEvent(active.samples(), {
     asamples. <- req(active.samples())
     nsamples <- nrow(asamples.)
-    value <- if (input$pcs > nsamples) nsamples else NULL
+    value <- if (req(input$pcs) > nsamples) nsamples else NULL
     updateNumericInput(session, "pcs", value = value, max = nsamples)
     toggleState("run", condition = nsamples >= 3L)
   })


### PR DESCRIPTION
Tests fail, but they failed before, too.

`shine()` on a `fpca` result did work, but likely because the UI was generated fast enough. When used in an [`insertUI()` context](https://github.com/facilebio/FacileIncubator/pull/3) it's possible to have it be too slow, so a `req()` of the `input` helps.